### PR TITLE
Use cell size instead of bit depth and additional samples

### DIFF
--- a/com.ibm.streamsx.transportation/.gitignore
+++ b/com.ibm.streamsx.transportation/.gitignore
@@ -1,3 +1,4 @@
 /.apt_generated/
 /.toolkitList
 /toolkit.xml
+/output/

--- a/com.ibm.streamsx.transportation/com.ibm.streamsx.transportation.vehicle/idle.spl
+++ b/com.ibm.streamsx.transportation/com.ibm.streamsx.transportation.vehicle/idle.spl
@@ -1,5 +1,5 @@
 // ************************************************************************
-// * Copyright (C)2014,2015, International Business Machines Corporation and
+// * Copyright (C)2014,2018, International Business Machines Corporation and
 // * others. All Rights Reserved.
 // ************************************************************************
 
@@ -23,12 +23,13 @@ type VehicleIdle = tuple<boolean idle, uint64 duration, rstring geohash>;
  * 
  * This is a wrapper around `com.ibm.streams.geospatial::Hangout` with
  * defaults suitable for a vehicle. The default settings match to the vehicle
- * being idle if it is in an 100mx100m (approximately) box (at the equator).
+ * being idle if it is in an 75mx75m (approximately) box.
  * 
  * For details on how to configure see the documentation for `com.ibm.streams.geospatial::Hangout`.
  * 
  * @param minimumIdle Time a vehicle must within a region to be seen as idle in seconds. 
- * @param geohashBitDepth Number of bits used to determine the size of each Geohash region. Defaults to `37u` which is approximately a 75m square at the equator.
+ * @param $geohashCellSize The extent of each Geohash region, in meters. Default is 75.0, which corresponds to geohash cells of roughly 75m x 75m in size.
+ * @param $sampleLatitude  Value indicating the latitude of the general area where the data is coming from. Default is 37, which corresponds to the San Fransisco area.
  * @param precision Specifies the distance, in meters, by which the computed boundaries of each Geohash region will be extended on all sides. Defaults to 25m.
  * @param timeoutFactor Specifies the timeout as a factor of `minimumIdle`. If no tuples have arrived for 
  * 
@@ -38,7 +39,10 @@ type VehicleIdle = tuple<boolean idle, uint64 duration, rstring geohash>;
 public composite IdleVehicleDetection(input VehicleLocations; output VehicleLocationsIdle) {
     param
        expression<float64> $minimumIdle;
-       expression<uint32> $geohashBitDepth : 37u;
+       expression<float64> $sampleLatitude: 37.0;
+       
+       expression<float64> $geohashCellSize : 75.0;
+       
        expression<float64> $precision : 25.0;
        expression<uint32> $timeoutFactor : 10u;
     graph
@@ -46,9 +50,10 @@ public composite IdleVehicleDetection(input VehicleLocations; output VehicleLoca
    stream<VehicleLocations, VehicleIdle> VehicleLocationsIdle = com.ibm.streams.geospatial::Hangout(VehicleLocations) {
       param
          minimumDwellTime: (uint32) $minimumIdle;
-         geohashBitDepth: $geohashBitDepth;
+         cellSize: $geohashCellSize;
          precision: $precision;
          timeStamp: reportTime;
+         sampleLatitude: $sampleLatitude;
          timeout: (uint32) ($minimumIdle * (float64) $timeoutFactor);
       output VehicleLocationsIdle:
          idle = IsInHangout(),

--- a/com.ibm.streamsx.transportation/info.xml
+++ b/com.ibm.streamsx.transportation/info.xml
@@ -3,8 +3,8 @@
   <info:identity>
     <info:name>com.ibm.streamsx.transportation</info:name>
     <info:description>Toolkit providing live data streams from transportation data sources and related functionality.</info:description>
-    <info:version>1.3.0</info:version>
-    <info:requiredProductVersion>4.0.1</info:requiredProductVersion>
+    <info:version>1.4.0</info:version>
+    <info:requiredProductVersion>4.2.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies>
     <info:toolkit>

--- a/samples/NextBusSamples/.settings/com.ibm.streamsx.transportation.hangout.demo.DetectHangoutEnd-BuildConfig2.splbuild
+++ b/samples/NextBusSamples/.settings/com.ibm.streamsx.transportation.hangout.demo.DetectHangoutEnd-BuildConfig2.splbuild
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>SPL Build Configuration: BuildConfig2</comment>
+<entry key="com.ibm.streams.studio.splproject:STATIC_LINKING">F</entry>
+<entry key="com.ibm.streams.studio.splproject:OPTIMIZED_CODE">T</entry>
+<entry key="com.ibm.streams.studio.splproject:FUSION_MODE">FDEF</entry>
+<entry key="com.ibm.streams.studio.splproject:MAIN_COMPOSITE">com.ibm.streamsx.transportation.hangout.demo::DetectHangoutEnd</entry>
+<entry key="com.ibm.streams.studio.splproject:NAME">BuildConfig2</entry>
+<entry key="com.ibm.streams.studio.splproject:GCC_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:SC_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:ACTIVE">F</entry>
+<entry key="com.ibm.streams.studio.splproject:LD_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:PRE_BUILD_CMD"/>
+<entry key="com.ibm.streams.studio.splproject:DATA_DIR"/>
+<entry key="com.ibm.streams.studio.splproject:POST_BUILD_CMD"/>
+<entry key="com.ibm.streams.studio.splproject:REPLACE_ENVIRONMENT">F</entry>
+<entry key="com.ibm.streams.studio.splproject:USE_PROJECT_DATA_DIR">T</entry>
+<entry key="com.ibm.streams.studio.splproject:PROFILING"/>
+<entry key="com.ibm.streams.studio.splproject:SDB">F</entry>
+<entry key="com.ibm.streams.studio.splproject:DEFAULT_POOL_SIZE"/>
+<entry key="com.ibm.streams.studio.splproject:OUTPUT_DIR">BuildConfig2</entry>
+<entry key="com.ibm.streams.studio.splproject:SAMPLING_RATE"/>
+<entry key="com.ibm.streams.studio.splproject:STANDALONE">F</entry>
+</properties>

--- a/samples/NextBusSamples/.settings/com.ibm.streamsx.transportation.hangout.demo.GroupAndRankHangouts-BuildConfig3.splbuild
+++ b/samples/NextBusSamples/.settings/com.ibm.streamsx.transportation.hangout.demo.GroupAndRankHangouts-BuildConfig3.splbuild
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>SPL Build Configuration: BuildConfig3</comment>
+<entry key="com.ibm.streams.studio.splproject:STATIC_LINKING">F</entry>
+<entry key="com.ibm.streams.studio.splproject:OPTIMIZED_CODE">T</entry>
+<entry key="com.ibm.streams.studio.splproject:FUSION_MODE">FDEF</entry>
+<entry key="com.ibm.streams.studio.splproject:MAIN_COMPOSITE">com.ibm.streamsx.transportation.hangout.demo::GroupAndRankHangouts</entry>
+<entry key="com.ibm.streams.studio.splproject:NAME">BuildConfig3</entry>
+<entry key="com.ibm.streams.studio.splproject:GCC_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:SC_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:ACTIVE">T</entry>
+<entry key="com.ibm.streams.studio.splproject:LD_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:PRE_BUILD_CMD"/>
+<entry key="com.ibm.streams.studio.splproject:DATA_DIR"/>
+<entry key="com.ibm.streams.studio.splproject:POST_BUILD_CMD"/>
+<entry key="com.ibm.streams.studio.splproject:REPLACE_ENVIRONMENT">F</entry>
+<entry key="com.ibm.streams.studio.splproject:USE_PROJECT_DATA_DIR">T</entry>
+<entry key="com.ibm.streams.studio.splproject:PROFILING"/>
+<entry key="com.ibm.streams.studio.splproject:SDB">F</entry>
+<entry key="com.ibm.streams.studio.splproject:DEFAULT_POOL_SIZE"/>
+<entry key="com.ibm.streams.studio.splproject:OUTPUT_DIR">BuildConfig3</entry>
+<entry key="com.ibm.streams.studio.splproject:SAMPLING_RATE"/>
+<entry key="com.ibm.streams.studio.splproject:STANDALONE">F</entry>
+</properties>

--- a/samples/NextBusSamples/.settings/com.ibm.streamsx.transportation.hangout.demo.SimpleNextBusHangout-BuildConfig1.splbuild
+++ b/samples/NextBusSamples/.settings/com.ibm.streamsx.transportation.hangout.demo.SimpleNextBusHangout-BuildConfig1.splbuild
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>SPL Build Configuration: BuildConfig1</comment>
+<entry key="com.ibm.streams.studio.splproject:STATIC_LINKING">F</entry>
+<entry key="com.ibm.streams.studio.splproject:OPTIMIZED_CODE">T</entry>
+<entry key="com.ibm.streams.studio.splproject:FUSION_MODE">FDEF</entry>
+<entry key="com.ibm.streams.studio.splproject:MAIN_COMPOSITE">com.ibm.streamsx.transportation.hangout.demo::SimpleNextBusHangout</entry>
+<entry key="com.ibm.streams.studio.splproject:NAME">BuildConfig1</entry>
+<entry key="com.ibm.streams.studio.splproject:GCC_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:SC_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:ACTIVE">T</entry>
+<entry key="com.ibm.streams.studio.splproject:LD_OPTS"/>
+<entry key="com.ibm.streams.studio.splproject:PRE_BUILD_CMD"/>
+<entry key="com.ibm.streams.studio.splproject:DATA_DIR"/>
+<entry key="com.ibm.streams.studio.splproject:POST_BUILD_CMD"/>
+<entry key="com.ibm.streams.studio.splproject:REPLACE_ENVIRONMENT">F</entry>
+<entry key="com.ibm.streams.studio.splproject:USE_PROJECT_DATA_DIR">T</entry>
+<entry key="com.ibm.streams.studio.splproject:PROFILING"/>
+<entry key="com.ibm.streams.studio.splproject:SDB">F</entry>
+<entry key="com.ibm.streams.studio.splproject:DEFAULT_POOL_SIZE"/>
+<entry key="com.ibm.streams.studio.splproject:OUTPUT_DIR">BuildConfig1</entry>
+<entry key="com.ibm.streams.studio.splproject:SAMPLING_RATE"/>
+<entry key="com.ibm.streams.studio.splproject:STANDALONE">F</entry>
+</properties>

--- a/samples/NextBusSamples/.settings/com.ibm.streamsx.transportation.sample.nextbus.MapVehiclePosition-BuildConfig.splbuild
+++ b/samples/NextBusSamples/.settings/com.ibm.streamsx.transportation.sample.nextbus.MapVehiclePosition-BuildConfig.splbuild
@@ -5,7 +5,7 @@
 <entry key="com.ibm.streams.studio.splproject:STATIC_LINKING">F</entry>
 <entry key="com.ibm.streams.studio.splproject:OPTIMIZED_CODE">T</entry>
 <entry key="com.ibm.streams.studio.splproject:FUSION_MODE">FDEF</entry>
-<entry key="com.ibm.streams.studio.splproject:MAIN_COMPOSITE">com.ibm.streamsx.transportation.sample.nextbus::VehiclePosition</entry>
+<entry key="com.ibm.streams.studio.splproject:MAIN_COMPOSITE">com.ibm.streamsx.transportation.sample.nextbus::MapVehiclePosition</entry>
 <entry key="com.ibm.streams.studio.splproject:NAME">BuildConfig</entry>
 <entry key="com.ibm.streams.studio.splproject:GCC_OPTS"/>
 <entry key="com.ibm.streams.studio.splproject:SC_OPTS"/>

--- a/samples/NextBusSamples/README.md
+++ b/samples/NextBusSamples/README.md
@@ -1,0 +1,15 @@
+# NextBus samples
+
+
+Sample applications in this project demonstrate using this toolkit to retreive and display NextBus data on a map.
+The `MapVehiclePosition` application is a separate application.
+
+### Hangout demo samples
+The samples in the `com.ibm.streamsx.transportation.hangout.demo` namespace also use the Hangout operator in the Geospatial toolkit to detect idle buses and compute some statistics with that data.
+To run those samples, first launch `SimpleNextBusHangout` to connect to NextBus and publish a stream of  detected hangouts, which will be used by the other 2 sample applications.
+These applications use live NextBus data, meaning that you might not get any hangouts detected even after leaving it running for a while.
+The defaults are to report a hangout after a bus is in the same 75x75m area for 3 minutes or more.
+If you are running one of the samples in that namespace and notice that you do not get any hangouts detected, try increasing the cell size or reducing the minimum dwell time.
+Note that this would probably no longer meet the definition of "idle", but it would help  you see some results for demonstration purposes.
+
+The hangout related samples will be discussed in a future article on Streamsdev.

--- a/samples/NextBusSamples/com.ibm.streamsx.transportation.hangout.demo/DetectHangoutEnd.spl
+++ b/samples/NextBusSamples/com.ibm.streamsx.transportation.hangout.demo/DetectHangoutEnd.spl
@@ -1,0 +1,55 @@
+
+// ************************************************************************
+// * Copyright (C)2018, International Business Machines Corporation and
+// * others. All Rights Reserved.
+// ************************************************************************
+namespace com.ibm.streamsx.transportation.hangout.demo ;
+
+use com.ibm.streamsx.transportation.nextbus::NextBusLocation ;
+
+use com.ibm.streams.cep::* ;
+use com.ibm.streamsx.topology.topic::* ;
+/***
+ * This composite just detects when a hangout ends and prints a message summarizing the hangout to the console.
+ * Subscribes to the output stream published by SimpleNextBusHangout, so that application must be running first.
+ */
+composite DetectHangoutEnd
+{
+	graph
+		stream<HangoutOutput> HangoutDetectionOutput = Subscribe()
+		{
+			param
+				topic : "BusAndHangoutData" ;
+				streamType : HangoutOutput ;
+		}
+		// Use the complex event processing operator MatchRegex to determine when an entity stops hanging out
+		stream<HangoutSummary> Case1_HangoutSummaries =
+			MatchRegex(HangoutDetectionOutput)
+		{
+			param
+				partitionBy : id ;
+				//The pattern is a tuple with hangingOut = true immediately followed by a tuple with isHangingOut = false
+				pattern : "hangout stop" ;
+				predicates : { hangout = idle == true, stop = idle == false } ;
+			output
+				Case1_HangoutSummaries : totalHangoutDuration = Max(duration), //the duration is the total time in that hangout, so use Max to get the highest reported duration
+				id = Any(id), geohash = First(geohash), lastSeenLatitude = First(latitude),
+					lastSeenLongitude = First(longitude), lastSeenTime = First(reportTime) ;
+		}
+		// log hangout start and stop to console
+		() as Case1_PrintHangoutSummary = Custom(Case1_HangoutSummaries as I)
+		{
+			logic
+				onTuple I :
+				{
+					float64 durationInMinutes =((float64) I.totalHangoutDuration) / 60.0 ;
+					printStringLn("Bus " + I.id + " spent " + formatNumber(durationInMinutes)
+						+ " minutes at geohash " + I.geohash + ", last seen there at " +
+						ctime(createTimestamp(lastSeenTime / 1000l, 0u))) ;
+				}
+
+			config
+				placement : partitionExlocation("printer") ;
+		}
+
+}

--- a/samples/NextBusSamples/com.ibm.streamsx.transportation.hangout.demo/GroupAndRankHangouts.spl
+++ b/samples/NextBusSamples/com.ibm.streamsx.transportation.hangout.demo/GroupAndRankHangouts.spl
@@ -1,0 +1,181 @@
+namespace com.ibm.streamsx.transportation.hangout.demo ;
+use com.ibm.streamsx.transportation.nextbus::NextBusLocation ;
+
+// ************************************************************************
+// * Copyright (C)2018, International Business Machines Corporation and
+// * others. All Rights Reserved.
+// ************************************************************************
+use com.ibm.streamsx.datetime.convert::* ;
+
+
+use com.ibm.streamsx.topology.topic::* ;
+/*
+ * As the name implies, this composite detects 2 things:
+ * 1) when 2 or more buses are hanging out in the same geohash
+ * 2) the top K geohashes based on number of buses hanging out in a geohash, where K is the numberToRank parameter.
+ * @param groupDwellTime the amount of time a bus must be within the geohash with other buses present, in milliseconds. Since a hangout is only detected
+ * when the bus has been there for at least 5 minutes, a small value like 90 seconds suffices in this case.
+ * @param numberToRank the value for K when computing the top K and bottom K values.
+ * This composite Subscribes to the output stream published by SimpleNextBusHangout, so that application must be running first.
+ * To detect more group hangouts:
+ * 	you can decrease the dwell time in the SimpleNextBusHangout  and/or increase the cell size.
+ 
+ */
+public composite GroupAndRankHangouts
+{
+	param
+		expression<int64> $groupDwellTime: 90000l;
+		expression<int32> $topK : (int32) getSubmissionTimeValue("numberToRank", "5");
+	graph
+		
+
+		stream<HangoutOutput> IdleBusStream = Subscribe()
+		{
+			param
+				topic : "IdleBusesOnly" ;
+				streamType : HangoutOutput ;
+		}
+		stream<HangoutsByGeohash> HangoutsByGeohash_ =
+			Aggregate(IdleBusStream as in0)
+		{
+			window
+				in0 : tumbling, delta(reportTime, $groupDwellTime) ;
+			param
+				groupBy : geohash ;
+			output
+				HangoutsByGeohash_ : total_geohashes = CountGroups(),
+				buses_in_hash = CollectDistinct(id), busCountPerHash =
+					CountDistinct(id), geohash = Any(geohash), firstReportTime = Min(reportTime);
+		}
+
+		stream<GroupHangoutsByGeohash> Filter_19_out0 = Functor(HangoutsByGeohash_ as inputStream)
+		{
+			param
+				filter : busCountPerHash >= 2 ;
+			output
+				Filter_19_out0 : firstTsString = ctime(createTimestamp(firstReportTime / 1000l,
+					0u)) ;
+		}
+		
+		stream<GroupHangoutsByGeohash> SortedDetailedHangout = Sort(Filter_19_out0 as in0){
+			
+			window
+			 in0: tumbling, punct();
+			param
+				sortBy: firstReportTime;
+				order: ascending;
+		}
+		
+		
+		
+		
+		
+		stream<list<int32> busesPerGeohash, list<rstring> geohashList,
+			int64 first_arrival_timeStamp> HangoutStats =
+			Aggregate(HangoutsByGeohash_)
+		{
+			window
+				HangoutsByGeohash_ : tumbling, punct() ;
+			output
+				HangoutStats : busesPerGeohash = Collect(busCountPerHash),
+					geohashList = Collect(geohash), first_arrival_timeStamp =
+					Min(firstReportTime) ;
+		}
+		
+
+		stream<list<GeohashAndCount> topHashes, 
+			int64 first_arrival_timeStamp, rstring firstArrivalTimeString> TopKHangouts as Out =
+			Functor(HangoutStats as In)
+		{
+			logic
+				state :
+				{
+					
+					mutable list<uint32> topIndices ;
+					mutable list<GeohashAndCount> topHashList = [];
+				}
+
+				onTuple In :
+				{
+					list<uint32> sortedIndices= sortIndices(busesPerGeohash);
+					topIndices = reverse(sortedIndices);
+					if(size(sortedIndices) > $topK) topIndices = slice(topIndices, 0, $topK) ;
+					 clearM(topHashList);
+					for (uint32 index in topIndices){
+						mutable GeohashAndCount t = {};
+						t.count = busesPerGeohash[index];
+						t.geohash = geohashList[index];
+						  appendM(topHashList, t);
+					}
+				}
+
+				output
+					Out : topHashes = topHashList,
+						firstArrivalTimeString = ctime(createTimestamp(first_arrival_timeStamp / 1000l, 0u)) ;
+
+			}
+
+		stream<list<rstring> bottomHashes, list<int32> busesPerGeohash,
+			int64 first_arrival_timeStamp, rstring firstArrivalTimeString> BottomKHangouts as Out =
+				Functor(HangoutStats as In)
+			{
+				logic
+					state :
+					{
+						mutable list<uint32> indices ;
+						mutable list<uint32> bottomIndices ;
+					}
+
+					onTuple In :
+					{
+						indices = sortIndices(busesPerGeohash) ;
+						if(size(indices) > $topK) indices = slice(indices, 0, $topK) ;
+					}
+
+					output
+						Out : bottomHashes = at(geohashList, indices), busesPerGeohash =
+							at(busesPerGeohash, indices), firstArrivalTimeString =
+							ctime(createTimestamp(first_arrival_timeStamp / 1000l, 0u)) ;
+
+				}
+
+			() as GroupHangoutPrinter = Custom(SortedDetailedHangout as In0){
+				logic
+					onTuple In0 :
+						{
+							
+							printStringLn("There are " + (rstring) In0.busCountPerHash + "  buses hanging out at geohash " + In0.geohash + ", the buses are " + (rstring)buses_in_hash + ".");
+						}
+				config
+						placement : partitionExlocation("printer") ;
+			}	
+		
+			() as TopKPrinter = Custom(TopKHangouts as In0)
+				{
+					logic
+						onTuple In0 :
+					{
+						rstring timeInSeconds = (rstring) ($groupDwellTime/1000l);
+						printStringLn("\n********Top Hangouts for the " + timeInSeconds + " second period starting at " + firstArrivalTimeString + " *************:");
+						for (GeohashAndCount t in topHashes){
+							printStringLn((rstring) t.count + "  buses at  " +  t.geohash);
+						}
+						printStringLn("**************************************");
+
+					}
+					config
+						placement : partitionExlocation("printer") ;
+			
+				}
+
+			() as BottomKSink = FileSink(BottomKHangouts as inPort0Alias)
+				{
+					param
+						file : "unpopular.txt" ;
+						flush : 1u ;
+				}
+
+
+		}
+
+	

--- a/samples/NextBusSamples/com.ibm.streamsx.transportation.hangout.demo/SimpleNextBusHangout.spl
+++ b/samples/NextBusSamples/com.ibm.streamsx.transportation.hangout.demo/SimpleNextBusHangout.spl
@@ -1,0 +1,91 @@
+
+// ************************************************************************
+// * Copyright (C)2018, International Business Machines Corporation and
+// * others. All Rights Reserved.
+// ************************************************************************
+namespace com.ibm.streamsx.transportation.hangout.demo ;
+
+use com.ibm.streamsx.transportation.nextbus::AgencyVehicleLocationPoll ;
+use com.ibm.streamsx.transportation.nextbus::NextBusLocation ;
+
+use com.ibm.streamsx.datetime.convert::* ;
+use com.ibm.streams.geospatial::Hangout ;
+use com.ibm.streamsx.topology.topic::* ;
+
+/**
+ * This composite serves as a data source, retrieving NextBus data, augmenting that stream with
+ * hangout detection, and then publishing that data as a stream for use by the other applications in this namespace.
+ * Works with NextBus data for any of the supported municipalities.
+ * @param agency id of transit agency to use. This application will retrieve data for buses in that city or municipality.
+ * See http://webservices.nextbus.com/service/publicXMLFeed?command=agencyList for a list of the available agencies.
+ * Default sf-muni is for San Fransisco.
+ * @param sampleLatitude sample latitude of the area where the buses are, default to 37 for San Fransisco.
+ */
+composite SimpleNextBusHangout
+{
+	param
+		
+		expression<rstring> $agency : getSubmissionTimeValue("agency", "sf-muni");
+		expression<float64> $minimumIdleInMinutes: (float64)getSubmissionTimeValue("idleTime", "3");
+        expression<float64> $sampleLatitude :(float64) getSubmissionTimeValue("sampleLatitude", "37");
+     graph
+		stream<NextBusLocation> BusLocationStream = AgencyVehicleLocationPoll()
+		{
+			param
+				agency : $agency ;
+				period :(float64) getSubmissionTimeValue("period", "30.0") ;
+		}
+		//
+		// Augment with info if the bus has  been idle for 3 minutes
+		stream<HangoutOutput> BusLocation_WithHangouts = Hangout(BusLocationStream)
+		{
+			param
+				minimumDwellTime :(uint32) minutes($minimumIdleInMinutes ) ;
+				cellSize : (float64)getSubmissionTimeValue("hangoutCellSize", "75"); //geohash cells of 75m x 75 m
+				sampleLatitude : $sampleLatitude ; //use 37 for San fransisco area
+				precision : 15.0 ;
+				timeStamp : reportTime ;
+			output
+				BusLocation_WithHangouts : 
+				idle = IsInHangout(), 
+				duration = HangoutDuration(), 
+				geohash = HangoutGeohashBase32() ;
+		}
+
+		// Export for use by other analytics
+		() as PublishHangoutDetection = Publish(BusLocation_WithHangouts)
+		{
+			param
+				topic : "BusAndHangoutData" ;
+		}
+
+		stream<HangoutOutput> IdleBusesOnly = Filter(BusLocation_WithHangouts as
+			HangoutDetectionOutput)
+		{
+			param
+				filter : idle ;
+		}
+
+		() as PublishIdleBuses= Publish(IdleBusesOnly)
+		{
+			param
+				topic : "IdleBusesOnly" ;
+		}
+
+
+		() as HangoutPrinter = Custom(IdleBusesOnly as In0)
+		{
+			logic
+				onTuple In0 :
+				{
+					rstring time =(rstring) In0.duration ;
+					printStringLn("Bus " + id + " has been  idle at geohash " + In0.geohash +
+						" for " + time + " seconds.") ;
+				}
+			config
+						placement : partitionExlocation("printer") ;
+			
+
+		}
+
+}

--- a/samples/NextBusSamples/com.ibm.streamsx.transportation.hangout.demo/Types.spl
+++ b/samples/NextBusSamples/com.ibm.streamsx.transportation.hangout.demo/Types.spl
@@ -1,0 +1,13 @@
+namespace com.ibm.streamsx.transportation.hangout.demo ;
+use com.ibm.streamsx.transportation.nextbus::NextBusLocation ;
+use com.ibm.streamsx.transportation.vehicle::VehicleIdle ;
+
+type HangoutsByGeohash = int64 firstReportTime, list<rstring> buses_in_hash, int32 busCountPerHash,
+			rstring geohash, int32 total_geohashes;
+type GroupHangoutsByGeohash = rstring firstTsString, int64 firstReportTime, list<rstring> buses_in_hash, int32 busCountPerHash,
+			rstring geohash;
+			
+type HangoutOutput = NextBusLocation, VehicleIdle ;
+type HangoutSummary = rstring id, uint64 totalHangoutDuration, rstring geohash,
+	int64 lastSeenTime, float64 lastSeenLatitude, float64 lastSeenLongitude ;
+type GeohashAndCount =tuple<rstring geohash, int32 count>;

--- a/samples/NextBusSamples/com.ibm.streamsx.transportation.sample.nextbus/MapVehiclePosition.spl
+++ b/samples/NextBusSamples/com.ibm.streamsx.transportation.sample.nextbus/MapVehiclePosition.spl
@@ -18,7 +18,7 @@ type MARKER_TYPE = enum { GREEN, YELLOW, RED, WARNING } ;
 /**
  * Fetch NextBus® vehicle location with idle bus detection.
  */
-public composite VehiclePosition
+public composite MapVehiclePosition
 {
     param
           expression<rstring> $agency : getSubmissionTimeValue("agency", "sf-muni");

--- a/samples/NextBusSamples/com.ibm.streamsx.transportation.sample.nextbus/VehiclePosition.spl
+++ b/samples/NextBusSamples/com.ibm.streamsx.transportation.sample.nextbus/VehiclePosition.spl
@@ -22,6 +22,9 @@ public composite VehiclePosition
 {
     param
           expression<rstring> $agency : getSubmissionTimeValue("agency", "sf-muni");
+	  
+          //Sample latitude of the area where the buses are, default to 37 for San Fransisco
+          expression<float64> $sampleLatitude :(float64) getSubmissionTimeValue("sampleLatitude", "37");
           expression<float64> $ageOutTime : minutes(15);
           expression<int32> $port : 8080;
 
@@ -50,6 +53,7 @@ public composite VehiclePosition
 	   // Augment with info if the bus has  been idle for 3 minutes
        stream<VLX, VehicleIdle> VLXWithIdle = IdleVehicleDetection(VLX) {
           param minimumIdle: minutes(3);
+	  sampleLatitude: $sampleLatitude;
        }
 
 

--- a/samples/NextBusSamples/info.xml
+++ b/samples/NextBusSamples/info.xml
@@ -16,12 +16,20 @@
       <common:version>[1.0.0,2.0.0)</common:version>
     </info:toolkit>
     <info:toolkit>
-      <common:name>com.ibm.streamsx.transportation</common:name>
-      <common:version>[1.1.0,2.0.0)</common:version>
-    </info:toolkit>
-    <info:toolkit>
       <common:name>com.ibm.streams.geospatial</common:name>
       <common:version>[3.0.0,4.0.0)</common:version>
+    </info:toolkit>
+    <info:toolkit>
+      <common:name>com.ibm.streamsx.transportation</common:name>
+      <common:version>[1.4.0,2.0.0)</common:version>
+    </info:toolkit>
+    <info:toolkit>
+      <common:name>com.ibm.streams.cep</common:name>
+      <common:version>[2.1.0,3.0.0)</common:version>
+    </info:toolkit>
+    <info:toolkit>
+      <common:name>com.ibm.streamsx.topology</common:name>
+      <common:version>[1.7.4,2.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>

--- a/samples/NextBusSamples/info.xml
+++ b/samples/NextBusSamples/info.xml
@@ -4,7 +4,7 @@
     <info:name>NextBusSamples</info:name>
     <info:description>Samples for NextBus data</info:description>
     <info:version>1.0.0</info:version>
-    <info:requiredProductVersion>4.0.0.0</info:requiredProductVersion>
+    <info:requiredProductVersion>4.2.0.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies>
     <info:toolkit>


### PR DESCRIPTION
Changeed idle.spl to use the cell size parameter added in Streams 4.2.
Added new hangout detection samples in a separate namespace.